### PR TITLE
Implement initial UI for VHDTools

### DIFF
--- a/VHDTools.App/App.xaml
+++ b/VHDTools.App/App.xaml
@@ -6,7 +6,7 @@
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <materialDesign:BundledTheme BaseTheme="Light" PrimaryColor="DeepPurple" SecondaryColor="Lime" />
+                <materialDesign:BundledTheme BaseTheme="Light" PrimaryColor="Indigo" SecondaryColor="Orange" />
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesign2.Defaults.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>

--- a/VHDTools.App/App.xaml.cs
+++ b/VHDTools.App/App.xaml.cs
@@ -10,6 +10,11 @@ namespace VHDTools.App
 
         protected override void RegisterTypes(IContainerRegistry containerRegistry)
         {
+            containerRegistry.RegisterSingleton<Services.IDiskService, Services.DiskService>();
+            containerRegistry.RegisterSingleton<Services.ISettingsService, Services.SettingsService>();
+
+            containerRegistry.RegisterForNavigation<Views.HomeView>();
+            containerRegistry.RegisterForNavigation<Views.SettingsView>();
         }
     }
 }

--- a/VHDTools.App/MainWindow.xaml
+++ b/VHDTools.App/MainWindow.xaml
@@ -2,9 +2,15 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+        xmlns:prism="http://prismlibrary.com/"
+        prism:ViewModelLocator.AutoWireViewModel="True"
         Title="VHD Tools" Height="450" Width="800"
         Style="{StaticResource MaterialDesignWindow}">
-    <Grid>
-        <TextBlock Text="Welcome to VHD Tools" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="20"/>
-    </Grid>
+    <DockPanel>
+        <StackPanel DockPanel.Dock="Left" Width="160" Background="{DynamicResource MaterialDesignPaper}">
+            <Button Content="Home" Command="{Binding NavigateCommand}" CommandParameter="HomeView" Margin="8"/>
+            <Button Content="Settings" Command="{Binding NavigateCommand}" CommandParameter="SettingsView" Margin="8"/>
+        </StackPanel>
+        <ContentControl prism:RegionManager.RegionName="ContentRegion" />
+    </DockPanel>
 </Window>

--- a/VHDTools.App/Services/DiskService.cs
+++ b/VHDTools.App/Services/DiskService.cs
@@ -1,0 +1,24 @@
+using DiskTools;
+
+namespace VHDTools.App.Services
+{
+    public class DiskService : IDiskService
+    {
+        public void CreateVirtualDisk(string path, long sizeBytes)
+        {
+            DiskManager.CreateVirtualDisk(path, VirtualDiskType.Vhdx, sizeBytes);
+        }
+
+        public void AttachVirtualDisk(string path)
+        {
+            using var manager = new DiskManager(path);
+            manager.AttachVirtualDisk();
+        }
+
+        public void DetachVirtualDisk(string path)
+        {
+            using var manager = new DiskManager(path);
+            manager.DetachVirtualDisk();
+        }
+    }
+}

--- a/VHDTools.App/Services/IDiskService.cs
+++ b/VHDTools.App/Services/IDiskService.cs
@@ -1,0 +1,9 @@
+namespace VHDTools.App.Services
+{
+    public interface IDiskService
+    {
+        void CreateVirtualDisk(string path, long sizeBytes);
+        void AttachVirtualDisk(string path);
+        void DetachVirtualDisk(string path);
+    }
+}

--- a/VHDTools.App/Services/ISettingsService.cs
+++ b/VHDTools.App/Services/ISettingsService.cs
@@ -1,0 +1,8 @@
+namespace VHDTools.App.Services
+{
+    public interface ISettingsService
+    {
+        AppSettings Settings { get; }
+        void Save();
+    }
+}

--- a/VHDTools.App/Services/SettingsService.cs
+++ b/VHDTools.App/Services/SettingsService.cs
@@ -1,0 +1,52 @@
+using System.IO;
+using System.Text.Json;
+
+namespace VHDTools.App.Services
+{
+    public class AppSettings
+    {
+        public string? LastVhdPath { get; set; }
+    }
+
+    public class SettingsService : ISettingsService
+    {
+        private const string FileName = "appsettings.json";
+
+        public AppSettings Settings { get; private set; } = new AppSettings();
+
+        public SettingsService()
+        {
+            Load();
+        }
+
+        private void Load()
+        {
+            try
+            {
+                if (File.Exists(FileName))
+                {
+                    var json = File.ReadAllText(FileName);
+                    var loaded = JsonSerializer.Deserialize<AppSettings>(json);
+                    if (loaded != null)
+                        Settings = loaded;
+                }
+            }
+            catch
+            {
+                Settings = new AppSettings();
+            }
+        }
+
+        public void Save()
+        {
+            try
+            {
+                var json = JsonSerializer.Serialize(Settings, new JsonSerializerOptions { WriteIndented = true });
+                File.WriteAllText(FileName, json);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/VHDTools.App/ViewModels/HomeViewModel.cs
+++ b/VHDTools.App/ViewModels/HomeViewModel.cs
@@ -1,0 +1,62 @@
+using Prism.Commands;
+using Prism.Mvvm;
+using VHDTools.App.Services;
+
+namespace VHDTools.App.ViewModels
+{
+    public class HomeViewModel : BindableBase
+    {
+        private readonly IDiskService _diskService;
+
+        private string _vhdPath = string.Empty;
+        private string _vhdSize = "100";
+
+        public HomeViewModel(IDiskService diskService)
+        {
+            _diskService = diskService;
+            CreateVhdCommand = new DelegateCommand(CreateVhd);
+            AttachVhdCommand = new DelegateCommand(AttachVhd);
+            DetachVhdCommand = new DelegateCommand(DetachVhd);
+        }
+
+        public string VhdPath
+        {
+            get => _vhdPath;
+            set => SetProperty(ref _vhdPath, value);
+        }
+
+        public string VhdSize
+        {
+            get => _vhdSize;
+            set => SetProperty(ref _vhdSize, value);
+        }
+
+        public DelegateCommand CreateVhdCommand { get; }
+        public DelegateCommand AttachVhdCommand { get; }
+        public DelegateCommand DetachVhdCommand { get; }
+
+        private void CreateVhd()
+        {
+            if (long.TryParse(VhdSize, out long sizeMb) && !string.IsNullOrWhiteSpace(VhdPath))
+            {
+                _diskService.CreateVirtualDisk(VhdPath, sizeMb * 1024 * 1024);
+            }
+        }
+
+        private void AttachVhd()
+        {
+            if (!string.IsNullOrWhiteSpace(VhdPath))
+            {
+                _diskService.AttachVirtualDisk(VhdPath);
+            }
+        }
+
+        private void DetachVhd()
+        {
+            if (!string.IsNullOrWhiteSpace(VhdPath))
+            {
+                _diskService.DetachVirtualDisk(VhdPath);
+            }
+        }
+    }
+}

--- a/VHDTools.App/ViewModels/MainWindowViewModel.cs
+++ b/VHDTools.App/ViewModels/MainWindowViewModel.cs
@@ -1,0 +1,27 @@
+using Prism.Commands;
+using Prism.Mvvm;
+using Prism.Regions;
+
+namespace VHDTools.App.ViewModels
+{
+    public class MainWindowViewModel : BindableBase
+    {
+        private readonly IRegionManager _regionManager;
+
+        public MainWindowViewModel(IRegionManager regionManager)
+        {
+            _regionManager = regionManager;
+            NavigateCommand = new DelegateCommand<string>(Navigate);
+        }
+
+        public DelegateCommand<string> NavigateCommand { get; }
+
+        private void Navigate(string view)
+        {
+            if (!string.IsNullOrEmpty(view))
+            {
+                _regionManager.RequestNavigate("ContentRegion", view);
+            }
+        }
+    }
+}

--- a/VHDTools.App/ViewModels/SettingsViewModel.cs
+++ b/VHDTools.App/ViewModels/SettingsViewModel.cs
@@ -1,0 +1,33 @@
+using Prism.Commands;
+using Prism.Mvvm;
+using VHDTools.App.Services;
+
+namespace VHDTools.App.ViewModels
+{
+    public class SettingsViewModel : BindableBase
+    {
+        private readonly ISettingsService _settingsService;
+        private string _lastUsedPath = string.Empty;
+
+        public SettingsViewModel(ISettingsService settingsService)
+        {
+            _settingsService = settingsService;
+            _lastUsedPath = settingsService.Settings.LastVhdPath ?? string.Empty;
+            SaveCommand = new DelegateCommand(Save);
+        }
+
+        public string LastUsedPath
+        {
+            get => _lastUsedPath;
+            set => SetProperty(ref _lastUsedPath, value);
+        }
+
+        public DelegateCommand SaveCommand { get; }
+
+        private void Save()
+        {
+            _settingsService.Settings.LastVhdPath = LastUsedPath;
+            _settingsService.Save();
+        }
+    }
+}

--- a/VHDTools.App/Views/HomeView.xaml
+++ b/VHDTools.App/Views/HomeView.xaml
@@ -1,0 +1,16 @@
+<UserControl x:Class="VHDTools.App.Views.HomeView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             xmlns:prism="http://prismlibrary.com/"
+             prism:ViewModelLocator.AutoWireViewModel="True">
+    <StackPanel Margin="16">
+        <TextBox Text="{Binding VhdPath}" Width="300" materialDesign:HintAssist.Hint="VHD Path" Margin="0,0,0,8"/>
+        <TextBox Text="{Binding VhdSize}" Width="150" materialDesign:HintAssist.Hint="Size (MB)" Margin="0,0,0,8"/>
+        <StackPanel Orientation="Horizontal">
+            <Button Content="Create" Command="{Binding CreateVhdCommand}" Margin="0,0,8,0"/>
+            <Button Content="Attach" Command="{Binding AttachVhdCommand}" Margin="0,0,8,0"/>
+            <Button Content="Detach" Command="{Binding DetachVhdCommand}"/>
+        </StackPanel>
+    </StackPanel>
+</UserControl>

--- a/VHDTools.App/Views/HomeView.xaml.cs
+++ b/VHDTools.App/Views/HomeView.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace VHDTools.App.Views
+{
+    public partial class HomeView : UserControl
+    {
+        public HomeView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/VHDTools.App/Views/SettingsView.xaml
+++ b/VHDTools.App/Views/SettingsView.xaml
@@ -1,0 +1,12 @@
+<UserControl x:Class="VHDTools.App.Views.SettingsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             xmlns:prism="http://prismlibrary.com/"
+             prism:ViewModelLocator.AutoWireViewModel="True">
+    <StackPanel Margin="16">
+        <TextBlock Text="Settings" FontSize="20" Margin="0,0,0,16"/>
+        <TextBox Text="{Binding LastUsedPath}" materialDesign:HintAssist.Hint="Last used VHD path" Width="300" Margin="0,0,0,8"/>
+        <Button Content="Save" Command="{Binding SaveCommand}" Width="100"/>
+    </StackPanel>
+</UserControl>

--- a/VHDTools.App/Views/SettingsView.xaml.cs
+++ b/VHDTools.App/Views/SettingsView.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace VHDTools.App.Views
+{
+    public partial class SettingsView : UserControl
+    {
+        public SettingsView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/todo.md
+++ b/todo.md
@@ -1,8 +1,8 @@
 # TODO
 
-- [ ] Implement main user interface for managing virtual disk files.
-- [ ] Integrate features from the VHDTools library.
-- [ ] Provide actions for creating, attaching and detaching VHD files.
-- [ ] Add settings and configuration management.
-- [ ] Set up Prism navigation and view models.
-- [ ] Customize Material Design theme colors.
+- [x] Implement main user interface for managing virtual disk files.
+- [x] Integrate features from the VHDTools library.
+- [x] Provide actions for creating, attaching and detaching VHD files.
+- [x] Add settings and configuration management.
+- [x] Set up Prism navigation and view models.
+- [x] Customize Material Design theme colors.


### PR DESCRIPTION
## Summary
- build initial WPF UI with Prism navigation
- add services for disk operations and settings
- implement basic Home and Settings views
- customize material theme colors
- check off completed tasks in todo

## Testing
- `dotnet build VHDTools.sln -c Release` *(fails: NETSDK1045 due to unsupported net9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68520771b920832faab2ba0057425f26